### PR TITLE
Fix unpair issue with PS3 guitar

### DIFF
--- a/GHLtarUtilityLite/PS3Guitar.cs
+++ b/GHLtarUtilityLite/PS3Guitar.cs
@@ -3,10 +3,6 @@ using LibUsbDotNet.Main;
 using Nefarius.ViGEm.Client.Targets;
 using Nefarius.ViGEm.Client.Targets.Xbox360;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Timers;
 
 namespace GHLtarUtilityLite
@@ -54,51 +50,53 @@ namespace GHLtarUtilityLite
                 var reader = device.OpenEndpointReader(ReadEndpointID.Ep01);
                 reader.Read(readBuffer, 100, out bytesRead);
 
-                // Set the fret inputs on the virtual 360 controller
-                byte frets = readBuffer[0];
-                controller.SetButtonState(Xbox360Button.A, (frets & 0x02) != 0x00); // B1
-                controller.SetButtonState(Xbox360Button.B, (frets & 0x04) != 0x00); // B2
-                controller.SetButtonState(Xbox360Button.Y, (frets & 0x08) != 0x00); // B3
-                controller.SetButtonState(Xbox360Button.X, (frets & 0x01) != 0x00); // W1
-                controller.SetButtonState(Xbox360Button.LeftShoulder, (frets & 0x10) != 0x00); // W2
-                controller.SetButtonState(Xbox360Button.RightShoulder, (frets & 0x20) != 0x00); // W3
-
-                // Set the strum bar values - can probably be more efficient but eh
-                byte strum = readBuffer[4];
-                if (strum == 0xFF)
+                // Prevent default 0x00 when no bytes are read
+                if (bytesRead > 0)
                 {
-                    // Strum Down
-                    controller.SetButtonState(Xbox360Button.Down, true);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, -32768);
-                    controller.SetButtonState(Xbox360Button.Up, false);
-                }
-                else if (strum == 0x00)
-                {
-                    // Strum Up
-                    controller.SetButtonState(Xbox360Button.Down, false);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, 32767);
-                    controller.SetButtonState(Xbox360Button.Up, true);
-                }
-                else
-                {
-                    // No Strum
-                    controller.SetButtonState(Xbox360Button.Down, false);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, 0);
-                    controller.SetButtonState(Xbox360Button.Up, false);
-                }
+                    // Set the fret inputs on the virtual 360 controller
+                    byte frets = readBuffer[0];
+                    controller.SetButtonState(Xbox360Button.A, (frets & 0x02) != 0x00); // B1
+                    controller.SetButtonState(Xbox360Button.B, (frets & 0x04) != 0x00); // B2
+                    controller.SetButtonState(Xbox360Button.Y, (frets & 0x08) != 0x00); // B3
+                    controller.SetButtonState(Xbox360Button.X, (frets & 0x01) != 0x00); // W1
+                    controller.SetButtonState(Xbox360Button.LeftShoulder, (frets & 0x10) != 0x00); // W2
+                    controller.SetButtonState(Xbox360Button.RightShoulder, (frets & 0x20) != 0x00); // W3
 
-                // Set the buttons (pause/HP only for now)
-                byte buttons = readBuffer[1];
-                controller.SetButtonState(Xbox360Button.Start, (buttons & 0x02) != 0x00); // Pause
-                controller.SetButtonState(Xbox360Button.Back, (buttons & 0x01) != 0x00); // Hero Power
-                controller.SetButtonState(Xbox360Button.LeftThumb, (buttons & 0x04) != 0x00); // GHTV Button
-                controller.SetButtonState(Xbox360Button.Guide, (buttons & 0x10) != 0x00); // Sync Button
+                    // Set the strum bar values - can probably be more efficient but eh
+                    byte strum = readBuffer[4];
+                    if (strum == 0xFF)
+                    {
+                        // Strum Down
+                        controller.SetButtonState(Xbox360Button.Down, true);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, -32768);
+                        controller.SetButtonState(Xbox360Button.Up, false);
+                    } else if (strum == 0x00)
+                    {
+                        // Strum Up
+                        controller.SetButtonState(Xbox360Button.Down, false);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, 32767);
+                        controller.SetButtonState(Xbox360Button.Up, true);
+                    } else
+                    {
+                        // No Strum
+                        controller.SetButtonState(Xbox360Button.Down, false);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, 0);
+                        controller.SetButtonState(Xbox360Button.Up, false);
+                    }
 
-                // Set the tilt and whammy
-                controller.SetAxisValue(Xbox360Axis.RightThumbY, (short)((readBuffer[6] * 0x101) - 32768));
-                controller.SetAxisValue(Xbox360Axis.RightThumbX, (short)((readBuffer[19] * 0x101) - 32768));
+                    // Set the buttons (pause/HP only for now)
+                    byte buttons = readBuffer[1];
+                    controller.SetButtonState(Xbox360Button.Start, (buttons & 0x02) != 0x00); // Pause
+                    controller.SetButtonState(Xbox360Button.Back, (buttons & 0x01) != 0x00); // Hero Power
+                    controller.SetButtonState(Xbox360Button.LeftThumb, (buttons & 0x04) != 0x00); // GHTV Button
+                    controller.SetButtonState(Xbox360Button.Guide, (buttons & 0x10) != 0x00); // Sync Button
 
-                // TODO: Proper D-Pad emulation
+                    // Set the tilt and whammy
+                    controller.SetAxisValue(Xbox360Axis.RightThumbY, (short)((readBuffer[6] * 0x101) - 32768));
+                    controller.SetAxisValue(Xbox360Axis.RightThumbX, (short)((readBuffer[19] * 0x101) - 32768));
+
+                    // TODO: Proper D-Pad emulation
+                }
             }
         }
 

--- a/PS3Guitar.cs
+++ b/PS3Guitar.cs
@@ -3,10 +3,6 @@ using LibUsbDotNet.Main;
 using Nefarius.ViGEm.Client.Targets;
 using Nefarius.ViGEm.Client.Targets.Xbox360;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Timers;
 
 namespace GHLtarUtility
@@ -54,51 +50,53 @@ namespace GHLtarUtility
                 var reader = device.OpenEndpointReader(ReadEndpointID.Ep01);
                 reader.Read(readBuffer, 100, out bytesRead);
 
-                // Set the fret inputs on the virtual 360 controller
-                byte frets = readBuffer[0];
-                controller.SetButtonState(Xbox360Button.A, (frets & 0x02) != 0x00); // B1
-                controller.SetButtonState(Xbox360Button.B, (frets & 0x04) != 0x00); // B2
-                controller.SetButtonState(Xbox360Button.Y, (frets & 0x08) != 0x00); // B3
-                controller.SetButtonState(Xbox360Button.X, (frets & 0x01) != 0x00); // W1
-                controller.SetButtonState(Xbox360Button.LeftShoulder, (frets & 0x10) != 0x00); // W2
-                controller.SetButtonState(Xbox360Button.RightShoulder, (frets & 0x20) != 0x00); // W3
-
-                // Set the strum bar values - can probably be more efficient but eh
-                byte strum = readBuffer[4];
-                if (strum == 0xFF)
+                // Prevent default 0x00 when no bytes are read
+                if (bytesRead > 0)
                 {
-                    // Strum Down
-                    controller.SetButtonState(Xbox360Button.Down, true);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, -32768);
-                    controller.SetButtonState(Xbox360Button.Up, false);
-                }
-                else if (strum == 0x00)
-                {
-                    // Strum Up
-                    controller.SetButtonState(Xbox360Button.Down, false);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, 32767);
-                    controller.SetButtonState(Xbox360Button.Up, true);
-                }
-                else
-                {
-                    // No Strum
-                    controller.SetButtonState(Xbox360Button.Down, false);
-                    controller.SetAxisValue(Xbox360Axis.LeftThumbY, 0);
-                    controller.SetButtonState(Xbox360Button.Up, false);
-                }
+                    // Set the fret inputs on the virtual 360 controller
+                    byte frets = readBuffer[0];
+                    controller.SetButtonState(Xbox360Button.A, (frets & 0x02) != 0x00); // B1
+                    controller.SetButtonState(Xbox360Button.B, (frets & 0x04) != 0x00); // B2
+                    controller.SetButtonState(Xbox360Button.Y, (frets & 0x08) != 0x00); // B3
+                    controller.SetButtonState(Xbox360Button.X, (frets & 0x01) != 0x00); // W1
+                    controller.SetButtonState(Xbox360Button.LeftShoulder, (frets & 0x10) != 0x00); // W2
+                    controller.SetButtonState(Xbox360Button.RightShoulder, (frets & 0x20) != 0x00); // W3
 
-                // Set the buttons (pause/HP only for now)
-                byte buttons = readBuffer[1];
-                controller.SetButtonState(Xbox360Button.Start, (buttons & 0x02) != 0x00); // Pause
-                controller.SetButtonState(Xbox360Button.Back, (buttons & 0x01) != 0x00); // Hero Power
-                controller.SetButtonState(Xbox360Button.LeftThumb, (buttons & 0x04) != 0x00); // GHTV Button
-                controller.SetButtonState(Xbox360Button.Guide, (buttons & 0x10) != 0x00); // Sync Button
+                    // Set the strum bar values - can probably be more efficient but eh
+                    byte strum = readBuffer[4];
+                    if (strum == 0xFF)
+                    {
+                        // Strum Down
+                        controller.SetButtonState(Xbox360Button.Down, true);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, -32768);
+                        controller.SetButtonState(Xbox360Button.Up, false);
+                    } else if (strum == 0x00)
+                    {
+                        // Strum Up
+                        controller.SetButtonState(Xbox360Button.Down, false);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, 32767);
+                        controller.SetButtonState(Xbox360Button.Up, true);
+                    } else
+                    {
+                        // No Strum
+                        controller.SetButtonState(Xbox360Button.Down, false);
+                        controller.SetAxisValue(Xbox360Axis.LeftThumbY, 0);
+                        controller.SetButtonState(Xbox360Button.Up, false);
+                    }
 
-                // Set the tilt and whammy
-                controller.SetAxisValue(Xbox360Axis.RightThumbY, (short)((readBuffer[6] * 0x101) - 32768));
-                controller.SetAxisValue(Xbox360Axis.RightThumbX, (short)((readBuffer[19] * 0x101) - 32768));
+                    // Set the buttons (pause/HP only for now)
+                    byte buttons = readBuffer[1];
+                    controller.SetButtonState(Xbox360Button.Start, (buttons & 0x02) != 0x00); // Pause
+                    controller.SetButtonState(Xbox360Button.Back, (buttons & 0x01) != 0x00); // Hero Power
+                    controller.SetButtonState(Xbox360Button.LeftThumb, (buttons & 0x04) != 0x00); // GHTV Button
+                    controller.SetButtonState(Xbox360Button.Guide, (buttons & 0x10) != 0x00); // Sync Button
 
-                // TODO: Proper D-Pad emulation
+                    // Set the tilt and whammy
+                    controller.SetAxisValue(Xbox360Axis.RightThumbY, (short)((readBuffer[6] * 0x101) - 32768));
+                    controller.SetAxisValue(Xbox360Axis.RightThumbX, (short)((readBuffer[19] * 0x101) - 32768));
+
+                    // TODO: Proper D-Pad emulation
+                }
             }
         }
 


### PR DESCRIPTION
This should fix the continuous up inputs when you unpair the guitar with the PS3/WiiU dongle  #1 . 